### PR TITLE
Cata ilabaca/add new test

### DIFF
--- a/eol_forum_notifications/management/commands/discussion_notification.py
+++ b/eol_forum_notifications/management/commands/discussion_notification.py
@@ -23,8 +23,6 @@ class Command(BaseCommand):
 
     def handle(self, *args, **options):
         logger.info('EolForumNoticationsCommand - Running send_notification()')
-        if not options['how_often']:
-            raise CommandError("EolForumNoticationsCommand - how_often must be specified")
         if options['how_often'] not in ['weekly', 'daily']:
             raise CommandError("EolForumNoticationsCommand - how_often must be 'weekly' or 'daily'")
         how_often = options['how_often']

--- a/eol_forum_notifications/tests.py
+++ b/eol_forum_notifications/tests.py
@@ -1,13 +1,18 @@
 # -*- coding: utf-8 -*-
 # Python Standard Libraries
 from collections import namedtuple
+from io import StringIO
 import json
 
 # Installed packages (via pip)
-from django.test import Client
+from django.contrib.auth.models import AnonymousUser
+from django.core.management import call_command
+from django.core.management.base import CommandError
+from django.http import HttpRequest, HttpResponse
+from django.test import Client, TestCase
 from django.test.utils import override_settings
 from django.urls import reverse
-from mock import patch
+from mock import patch, MagicMock
 
 # Edx dependencies
 from common.djangoapps.student.roles import CourseStaffRole
@@ -19,8 +24,8 @@ from xmodule.modulestore.tests.factories import CourseFactory
 
 # Internal project dependencies
 from .models import EolForumNotificationsUser, EolForumNotificationsDiscussions
-from .utils import get_user_data, get_info_block_course
-from .views import send_notification
+from .utils import get_user_data, get_info_block_course, get_block_info
+from .views import send_notification, save_notification, save_notification_get, save_notification_post
 
 class TestRequest(object):
     # pylint: disable=too-few-public-methods
@@ -74,6 +79,13 @@ class TestNotifiactionsDiscussion(UrlResetMixin, ModuleStoreTestCase):
                 course_id=self.course.id)
             CourseStaffRole(self.course.id).add_users(self.staff_user)
 
+    def test_EolForumNotificationsDiscussions_str_function(self):
+        """
+            Tests that the __str__ method returns the expected format:
+            '<discussion_id> - <forum_path>'.
+        """
+        self.assertEqual(self.discussion.__str__(),'1234567890 - foo/baz/bar')
+
     def test_save_notifications(self):
         """
             save_notifications() normal process
@@ -108,6 +120,25 @@ class TestNotifiactionsDiscussion(UrlResetMixin, ModuleStoreTestCase):
             reverse('eol_discussion_notification:save'), post_data)
         self.assertEqual(response.status_code, 302)
         self.assertFalse(EolForumNotificationsUser.objects.filter(user=self.student, discussion=self.discussion).exists())
+
+    def test_save_notifications_user_anonymous(self):
+        """
+        Tests save_notifications() when called by an anonymous user. 
+        The view is protected with @login_required, so the function is invoked directly 
+        without using reverse or making an HTTP request.
+        """
+        post_data = {
+            'period': "daily",
+            'discussion_id': self.discussion.discussion_id,
+            'course_id': str(self.course.id),
+            'user_id': str(self.student.id)
+        }
+        request = TestRequest()
+        request.method = 'POST'
+        request.POST =  post_data
+        request.user = AnonymousUser()
+        response = save_notification(request)
+        self.assertEqual(response.status_code, 400)
 
     def test_save_notifications_wrong_method(self):
         """
@@ -203,7 +234,7 @@ class TestNotifiactionsDiscussion(UrlResetMixin, ModuleStoreTestCase):
             reverse('eol_discussion_notification:save'), post_data)
         self.assertEqual(response.status_code, 400)
         self.assertFalse(EolForumNotificationsUser.objects.filter(user=self.student, discussion=post_data['discussion_id']).exists())
-    
+
     @override_settings(PLATFORM_NAME='Test')
     @override_settings(LMS_ROOT_URL='https://test.ts')
     @patch('eol_forum_notifications.views.get_block_info')
@@ -289,7 +320,65 @@ class TestNotifiactionsDiscussion(UrlResetMixin, ModuleStoreTestCase):
         self.assertEqual(aux.daily_comment, 0)
         self.assertEqual(aux.weekly_threads, 3)
         self.assertEqual(aux.weekly_comment, 3)
-    
+
+    @override_settings(PLATFORM_NAME='Test')
+    @override_settings(LMS_ROOT_URL='https://test.ts')
+    @patch('eol_forum_notifications.views.get_block_info')
+    @patch('eol_forum_notifications.utils.course_image_url')
+    @patch('eol_forum_notifications.utils.get_course_by_id')
+    def test_send_notifications_daily_empty_block_parents(self, course_mock, image_mock, block_mock):
+        """
+        Ensure that the send_notifications() function correctly skips blocks with an undefined parent (block['parent'] == ""), 
+        logs the appropriate message, and does not raise any errors or continue processing that block.test send_notifications() 
+        daily period when block have empty parents
+        """
+        course_mock.side_effect = [namedtuple("Course", ["display_name_with_default", "end"])("this is a display name", None)]
+        image_mock.return_value = '/assets/image.jpg'
+        block_mock.return_value = {'display_name':'Test discussion xblock', 'parent': ''}
+        self.discussion.daily_threads = 3
+        self.discussion.daily_comment = 3
+        self.discussion.weekly_threads = 3
+        self.discussion.weekly_comment = 3
+        self.discussion.save()
+        with self.assertLogs('eol_forum_notifications.views', level='INFO') as cm:
+            send_notification('daily')
+        self.assertTrue(any('INFO:eol_forum_notifications.views:EolForumNotification - Block id doesnt exists, block-v1:eol+test100+2021_1+type@eoldiscussion+block@5c13942678184cab9a5345b660292c6e, course: foo/baz/bar' in log for log in cm.output))
+
+    @patch('eol_forum_notifications.views.get_current_site')
+    @patch('eol_forum_notifications.views.get_block_info')
+    @patch('eol_forum_notifications.utils.course_image_url')
+    @patch('eol_forum_notifications.utils.get_course_by_id')
+    def test_send_notifications_test_get_current_site(self, course_mock, image_mock, block_mock, mock_get_current_site):
+        """
+            Test send_notifications() ensuring that no error is logged when get_current_site() is patched to return a valid site configuration. 
+            This confirms that the platform name and LMS URL are retrieved successfully and the exception handling path is not triggered.
+        """
+        config_values = {
+            'PLATFORM_NAME': 'Test_2',
+            'ROOT': 'https://test_2.ts'
+        }
+        # Use mock and make a dictionary
+        mock_get_value = MagicMock(side_effect=lambda key, default=None: config_values.get(key, default))
+        mock_site = MagicMock()
+        mock_site.configuration.get_value = mock_get_value
+        mock_get_current_site.return_value = mock_site
+        
+        course_mock.side_effect = [namedtuple("Course", ["display_name_with_default", "end"])("this is a display name", None)]
+        image_mock.return_value = '/assets/image.jpg'
+        block_mock.return_value = {'display_name':'Test discussion xblock', 'parent': 'parent_test'}
+        self.discussion.daily_threads = 3
+        self.discussion.daily_comment = 3
+        self.discussion.weekly_threads = 3
+        self.discussion.weekly_comment = 3
+        self.discussion.save()
+        with self.assertLogs('eol_forum_notifications.views', level='INFO') as cm:
+            send_notification('daily')
+        aux = EolForumNotificationsDiscussions.objects.get(id=self.discussion.id)
+        self.assertEqual(aux.daily_threads, 0)
+        self.assertFalse(any(
+        'EolForumNotification - Error to get platform name and url site' in log
+        for log in cm.output))
+
     @patch('eol_forum_notifications.utils.get_info_block_course')
     def test_save_notifications_get(self, block_course):
         """
@@ -309,7 +398,7 @@ class TestNotifiactionsDiscussion(UrlResetMixin, ModuleStoreTestCase):
         request = response.request
         self.assertEqual(response.status_code, 200)
         self.assertEqual(request['PATH_INFO'], '/eol_discussion_notification/get_save/')
-    
+
     def test_save_notifications_get_no_user_model(self):
         """
             test save_notifications_get() when user dont have eol-forum-notification-user model
@@ -322,7 +411,7 @@ class TestNotifiactionsDiscussion(UrlResetMixin, ModuleStoreTestCase):
         response = self.client.get(reverse('eol_discussion_notification:save_get'), get_data)
         request = response.request
         self.assertEqual(response.status_code, 404)
-    
+
     def test_save_notifications_get_wrong_method(self):
         """
             test save_notifications_get() wrong method
@@ -335,10 +424,10 @@ class TestNotifiactionsDiscussion(UrlResetMixin, ModuleStoreTestCase):
         response = self.client.post(reverse('eol_discussion_notification:save_get'), get_data)
         request = response.request
         self.assertEqual(response.status_code, 400)
-    
+
     def test_save_notifications_get_anonymous_user(self):
         """
-            test save_notifications_get() when useris anonymous
+            test save_notifications_get() with anonymous user
         """
         get_data = {
             'discussion_id': self.discussion.discussion_id,
@@ -349,7 +438,26 @@ class TestNotifiactionsDiscussion(UrlResetMixin, ModuleStoreTestCase):
         response = client.get(reverse('eol_discussion_notification:save_get'), get_data)
         request = response.request
         self.assertEqual(response.status_code, 302)
-    
+
+    def test_save_notifications_get_user_anonymous(self):
+        """
+        Tests save_notifications_get() when called by an anonymous user.
+        Since the view is protected with @login_required, the function is tested directly
+        without using reverse or making an HTTP request.
+        """
+        get_data = {
+            'discussion_id': self.discussion.discussion_id,
+            'course_id': str(self.discussion.course_id),
+            'user_id': self.student.id,
+        }
+        request = TestRequest()
+        request.method = 'GET'
+        request.GET =  get_data
+        request.user = AnonymousUser()
+        response = save_notification_get(request)
+        self.assertEqual(response.status_code, 404)
+        self.assertEqual(response.content.decode(),'Inicie sesión y vuelva a presionar el link.')
+
     def test_save_notifications_get_wrong_user_id(self):
         """
             test save_notifications_get() when user id request is not equal to params user id
@@ -362,7 +470,7 @@ class TestNotifiactionsDiscussion(UrlResetMixin, ModuleStoreTestCase):
         response = self.client.get(reverse('eol_discussion_notification:save_get'), get_data)
         request = response.request
         self.assertEqual(response.status_code, 404)
-    
+
     def test_save_notifications_get_missing_params(self):
         """
             test save_notifications_get() when missing some params
@@ -374,7 +482,7 @@ class TestNotifiactionsDiscussion(UrlResetMixin, ModuleStoreTestCase):
         response = self.client.get(reverse('eol_discussion_notification:save_get'), get_data)
         request = response.request
         self.assertEqual(response.status_code, 404)
-    
+
     def test_save_notifications_post(self):
         """
             test save_notifications_post() normal process
@@ -391,7 +499,7 @@ class TestNotifiactionsDiscussion(UrlResetMixin, ModuleStoreTestCase):
         self.assertTrue(EolForumNotificationsUser.objects.filter(user=self.student, discussion=self.discussion).exists())
         self.assertEqual(response.status_code, 200)
         self.assertEqual(request['PATH_INFO'], '/eol_discussion_notification/post_save/')
-    
+
     def test_save_notifications_post_wrong_method(self):
         """
             test save_notifications_post() wrong method
@@ -406,7 +514,7 @@ class TestNotifiactionsDiscussion(UrlResetMixin, ModuleStoreTestCase):
         response = self.client.get(reverse('eol_discussion_notification:save_post'), post_data)
         self.assertFalse(EolForumNotificationsUser.objects.filter(user=self.student, discussion=self.discussion).exists())
         self.assertEqual(response.status_code, 400)
-    
+
     def test_save_notifications_post_missing_params(self):
         """
             test save_notifications_post() when missing some params
@@ -421,7 +529,7 @@ class TestNotifiactionsDiscussion(UrlResetMixin, ModuleStoreTestCase):
         self.assertFalse(EolForumNotificationsUser.objects.filter(user=self.student, discussion=self.discussion).exists())
         self.assertEqual(response.status_code, 200)
         self.assertTrue("id=\"wrong_data\"" in response._container[0].decode())
-    
+
     def test_save_notifications_post_user_anonymous(self):
         """
             test save_notifications_post() when user is anonymous
@@ -437,6 +545,31 @@ class TestNotifiactionsDiscussion(UrlResetMixin, ModuleStoreTestCase):
         response = client.post(reverse('eol_discussion_notification:save_post'), post_data)
         self.assertFalse(EolForumNotificationsUser.objects.filter(user=self.student, discussion=self.discussion).exists())
         self.assertEqual(response.status_code, 302)
+
+    @patch('eol_forum_notifications.views.render')
+    def test_save_notifications_post_anonymous_user(self, mock_render):
+        """
+            save_notification_post() when user is anonymous and have an html as a response
+        """
+        mock_render.return_value = HttpResponse('Inicie sesión y vuelva a presionar el link.')
+        post_data = {
+            'discussion_id': self.discussion.discussion_id,
+            'course_id': str(self.discussion.course_id),
+            'user_id': self.student.id,
+            'period': 'never'
+        }
+        request = HttpRequest()
+        request.method = 'POST'
+        request.POST =  post_data
+        request.user = AnonymousUser()
+        response = save_notification_post(request)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.content.decode(),'Inicie sesión y vuelva a presionar el link.')
+        mock_render.assert_called_with(
+            request,
+            'eol_forum_notifications/notification.html',
+            {'error': 'Inicie sesión y vuelva a presionar el link del correo.'}
+        )
 
     def test_save_notifications_post_user_id_wrong(self):
         """
@@ -470,6 +603,22 @@ class TestNotifiactionsDiscussion(UrlResetMixin, ModuleStoreTestCase):
         self.assertEqual(response.status_code, 200)
         self.assertTrue("id=\"wrong_data\"" in response._container[0].decode())
 
+    def test_save_notifications_post_course_id_wrong(self):
+        """
+            test save_notifications_post() when course_id is wrong
+        """
+        post_data = {
+            'discussion_id': self.discussion.discussion_id,
+            'course_id': str('11111111111111111'),
+            'user_id': self.student.id,
+            'period': 'never'
+        }
+        self.assertFalse(EolForumNotificationsUser.objects.filter(user=self.student, discussion=self.discussion).exists())
+        response = self.client.post(reverse('eol_discussion_notification:save_post'), post_data)
+        self.assertFalse(EolForumNotificationsUser.objects.filter(user=self.student, discussion=self.discussion).exists())
+        self.assertEqual(response.status_code, 200)
+        self.assertIn(' Un error inesperado ha ocurrido, por favor', response.content.decode())
+
     def test_utils_get_user_data_non_existing_discussion_id(self):
         """
         Test error when discussion_id doesn't exist
@@ -487,16 +636,66 @@ class TestNotifiactionsDiscussion(UrlResetMixin, ModuleStoreTestCase):
 
     def test_utils_get_user_data(self):
         """
-        Test get_user_data with expecting path
+        Test get_user_data with expected path
         """
         user_notif = EolForumNotificationsUser.objects.create(discussion=self.discussion, user=self.student, how_often="daily")
         response=get_user_data('1234567890', self.student, self.course.id, self.block_key)
         response_data = json.loads(response)
         self.assertEqual(response_data['how_often'], 'daily')
-    
+
     def test_utils_get_info_block_course_wrong_user_id(self):
         """
         Test error when user in notification is different from request user
         """
         info = get_info_block_course(self.discussion.id, 'course_test_wrong')
         self.assertEqual(info, None)
+
+    @patch('eol_forum_notifications.utils.modulestore')
+    def test_utils_get_block_info(self, mock_modulestore):
+        """
+        Test get_block_info with expected path
+        """
+        mock_block_key = MagicMock()
+        mock_block_key.course_key = 'dummy-course-key'
+
+        # Create a mock of the store and its methods
+        mock_store = MagicMock()
+        mock_block = MagicMock()
+        mock_block.display_name = "title test"
+        mock_block.parent = "parent-id"
+
+        # Configure mocks
+        mock_store.get_item.return_value = mock_block
+        mock_modulestore.return_value = mock_store
+
+        # Use context manager mock
+        mock_store.bulk_operations.return_value.__enter__.return_value = None
+        mock_store.bulk_operations.return_value.__exit__.return_value = None
+
+        result = get_block_info(mock_block_key)
+        expected = {
+            'display_name': "title test",
+            'parent': "parent-id"
+        }
+        self.assertEqual(result, expected)
+
+
+class CommandTest(TestCase):
+    @patch('eol_forum_notifications.management.commands.discussion_notification.send_notification')
+    def test_command_discussion_notification(self,mock_send_notification):
+        """
+        Test discussion_notification
+            1. Without how_often
+            2. with wrong alternative to how_often
+            3. Normal process
+        """
+        mock_send_notification.return_value = True
+        out = StringIO()
+        with self.assertRaises(CommandError):
+            call_command('discussion_notification', stdout=out)
+            self.assertTrue(out)
+        with self.assertRaises(CommandError) as cm:
+            call_command('discussion_notification','hourly', stdout=out)
+        self.assertIn("EolForumNoticationsCommand - how_often must be 'weekly' or 'daily'", str(cm.exception))
+        call_command('discussion_notification','daily', stdout=out)
+        self.assertTrue(out)

--- a/setup.cfg
+++ b/setup.cfg
@@ -12,3 +12,7 @@ junit_family = xunit2
 norecursedirs = .* *.egg build conf dist node_modules test_root wf_tmp
 python_classes =
 python_files = tests.py
+
+[coverage:run]
+omit =
+    */migrations/*

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ import setuptools
 
 setuptools.setup(
     name="eol_forum_notifications",
-    version="1.0.0",
+    version="1.0.1",
     author="Oficina EOL UChile",
     author_email="eol-ing@uchile.cl",
     description="Allows you to save forum notification and send mails with threads and/or comments unread among other things",


### PR DESCRIPTION
Se agregan nuevos test para alcanzar el 99% del coverage la unica linea que no se logra toca es una que no es inalcanzable y no sabia si borrar o no el código. Se agregan test y se modifica el setup.cfg para que no tome en cuenta las migraciones al momento de hacer el reporte 