### PR TITLE
Cata ilabaca/remove inside importations

### DIFF
--- a/eol_forum_notifications/views.py
+++ b/eol_forum_notifications/views.py
@@ -19,6 +19,7 @@ from opaque_keys.edx.keys import CourseKey
 
 # Internal project dependencies
 from .models import EolForumNotificationsUser, EolForumNotificationsDiscussions
+from .tasks import task_send_single_email
 from .utils import get_users_notifications, get_courses_onlive, get_block_info, get_info_block_course
 
 logger = logging.getLogger(__name__)
@@ -148,7 +149,6 @@ def send_notification(how_often):
     """
         Send email with threads and/or comments unreaded
     """
-    from .tasks import task_send_single_email
     try:
         current_site = get_current_site()
         platform_name =  current_site.configuration.get_value('PLATFORM_NAME', settings.PLATFORM_NAME)

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ import setuptools
 
 setuptools.setup(
     name="eol_forum_notifications",
-    version="1.0.2",
+    version="1.0.3",
     author="Oficina EOL UChile",
     author_email="eol-ing@uchile.cl",
     description="Allows you to save forum notification and send mails with threads and/or comments unread among other things",


### PR DESCRIPTION
Se deja la importación hacia afuera de la función, es la ultima importación dentro de función que quedaba en el código 